### PR TITLE
[FIX] November 2025 Audit report fixes

### DIFF
--- a/core/src/integrations/router/BackrunEnabledSwapProxy.sol
+++ b/core/src/integrations/router/BackrunEnabledSwapProxy.sol
@@ -110,7 +110,7 @@ contract BackrunEnabledSwapProxy is ReentrancyGuard {
 
         // ============ Security Cleanup ============
 
-        // Reset approval to 0 for security (prevents approval race conditions)
+        // Reset approval to 0 for security
         IERC20(swapMetadata.tokenIn).forceApprove(targetRouter, 0);
 
         // ============ Return Leftover Funds ============


### PR DESCRIPTION
# Security Audit Fixes - BackrunEnabledSwapProxy Contract

## Overview


This PR addresses security findings from the **Optimum Blockchain Security audit** (November 2025) for the `BackrunEnabledSwapProxy` contract. All identified issues have been resolved through architectural improvements and code cleanup.

Full report 
[(Preliminary) november-2025-reflex-security-assessment.pdf](https://github.com/user-attachments/files/23439069/Preliminary.november-2025-reflex-security-assessment.pdf)
---

## 🔒 Security Audit Summary

**Audit Firm:** Optimum Blockchain Security (@0xOptimum)  
**Audit Date:** November 2025  
**Findings:** 3 issues (1 Low, 2 Info)  
**Status:** ✅ All findings resolved

---

## 📋 Findings & Resolutions

### 1. ❗ Handling of Incoming Output Tokens (Low Severity)

**Finding:**  
Location: `BackrunEnabledSwapProxy.sol#L88`

The original `swapWithbackrun()` function allowed calling arbitrary DEX routers via `targetRouter.call()` with arbitrary parameters. While most DEX routers send output tokens to a specified recipient, some routers might send output tokens to `msg.sender` (the proxy contract itself). This could result in tokens being trapped in the proxy contract, making them vulnerable to theft by subsequent callers.

**Resolution:**

✅ **Introduced `SwapMetadata` struct** with the following fields:
```solidity
struct SwapMetadata {
    bytes swapTxCallData;
    address tokenIn;
    uint256 amountIn;
    address tokenOut;     // ← NEW: Track output token
    address recipient;     // ← NEW: Specify recipient
}
```

✅ **Added automatic output token cleanup:**
```solidity
// Check for leftover output tokens after swap
uint256 tokenOutBalanceAfter = IERC20(swapMetadata.tokenOut).balanceOf(address(this));
if (tokenOutBalanceAfter > 0) {
    // Return any remaining output tokens to the specified recipient
    IERC20(swapMetadata.tokenOut).safeTransfer(swapMetadata.recipient, tokenOutBalanceAfter);
}
```

**Impact:**
- ✅ Output tokens are automatically detected and transferred to the designated recipient
- ✅ No tokens can remain trapped in the proxy contract
- ✅ Works with any DEX router implementation (recipient in calldata OR msg.sender)
- ✅ Supports different recipient than the caller for advanced use cases

---

### 2. ℹ️ Transfer to Specific Recipient (Info Severity)

**Finding:**  
Location: `BackrunEnabledSwapProxy.sol#L149-L163`

The original implementation transferred leftover native tokens and `tokenIn` back to `msg.sender` instead of allowing a specified recipient. This limited flexibility and didn't align with best practices for DeFi composability.

**Resolution:**

✅ **Added `recipient` field to `SwapMetadata` struct:**
- Output tokens (`tokenOut`) are sent to `swapMetadata.recipient`
- Leftover input tokens (`tokenIn`) are still returned to `msg.sender` (original caller) as they were never consumed
- ETH is returned to `msg.sender` (original caller) as they funded the transaction

**Rationale:**
```solidity
// Input tokens - return to caller (they provided these)
if (tokenInBalanceAfter > 0) {
    IERC20(swapMetadata.tokenIn).safeTransfer(msg.sender, tokenInBalanceAfter);
}

// Output tokens - send to specified recipient
if (tokenOutBalanceAfter > 0) {
    IERC20(swapMetadata.tokenOut).safeTransfer(swapMetadata.recipient, tokenOutBalanceAfter);
}

// ETH - return to caller (they funded this)
if (ethBalanceAfter > 0) {
    (bool ethSuccess,) = payable(msg.sender).call{value: ethBalanceAfter}("");
    if (!ethSuccess) revert ETHTransferFailed();
}
```

**Impact:**
- ✅ Flexible recipient management for output tokens
- ✅ Supports use cases where swap output should go to a different address
- ✅ Maintains security by returning unused funds to original caller
- ✅ Enables better composability with other DeFi protocols

---

### 3. 🧹 Redundant Code Removal (Info Severity)

**Finding:**  
Location: Multiple locations in `BackrunEnabledSwapProxy.sol`

The audit identified several pieces of redundant code:
1. Balance and allowance checks of the sender (lines 110-120)
2. Calling `forceApprove` with 0 (line 130)
3. Sanity checks for leftover balances (lines 165-177)
4. Setting profits and profitTokens to 0 (lines 203-207)

**Resolution:**

✅ **Removed redundant balance/allowance checks:**
- **Before:** Manual checks with custom errors `InsufficientBalance` and `InsufficientAllowance`
- **After:** Rely on OpenZeppelin's `SafeERC20.safeTransferFrom()` which handles these checks natively
- **Benefit:** Reduced gas costs, cleaner code, leverages battle-tested library

✅ **Converted sanity checks to automatic cleanup:**
- **Before:** Reverted with `LeftoverTokenBalance` or `LeftoverETHBalance` errors
- **After:** Removed this checks are those unnecessary as we have full refund logic and the checks were just more declarative 
- **Benefit:**  More user-friendly

✅ **Removed explicit zero initialization:**
- **Before:** `profits[i] = 0; profitTokens[i] = address(0);`
- **After:** Arrays are automatically initialized to zero values in Solidity
- **Benefit:** Reduced bytecode size and deployment gas costs

