### PR TITLE
[FEAT] Add protocol fee discount system for V4 Hooks

### DIFF
--- a/core/src/integrations/plugin/ReflexAfterSwap.sol
+++ b/core/src/integrations/plugin/ReflexAfterSwap.sol
@@ -20,6 +20,17 @@ abstract contract ReflexAfterSwap {
     /// @param newConfigId The new configuration ID
     event ReflexConfigIdUpdated(bytes32 oldConfigId, bytes32 newConfigId);
 
+    /// @notice Emitted when a global fee discount is set or removed
+    /// @param user The address receiving (or losing) the discount
+    /// @param discount Whether the discount is active
+    event GlobalFeeDiscountSet(address indexed user, bool discount);
+
+    /// @notice Emitted when a pool-specific fee discount is set or removed
+    /// @param poolId The pool ID the discount applies to
+    /// @param user The address receiving (or losing) the discount
+    /// @param discount Whether the discount is active
+    event PoolFeeDiscountSet(bytes32 indexed poolId, address indexed user, bool discount);
+
     // ========== State Variables ==========
 
     /// @notice Address of the Reflex router contract
@@ -27,6 +38,12 @@ abstract contract ReflexAfterSwap {
 
     /// @notice Configuration ID for profit distribution
     bytes32 reflexConfigId;
+
+    /// @notice Global fee discounts — address gets 100% fee discount on all pools
+    mapping(address => bool) public globalFeeDiscount;
+
+    /// @notice Per-pool fee discounts — address gets 100% fee discount on a specific pool
+    mapping(bytes32 => mapping(address => bool)) public poolFeeDiscount;
 
     /// @notice Constructor to initialize the ReflexAfterSwap contract
     /// @param _router Address of the Reflex router contract
@@ -36,6 +53,7 @@ abstract contract ReflexAfterSwap {
         require(_router != address(0), "Invalid router address");
         reflexRouter = _router;
         reflexConfigId = _configId;
+        globalFeeDiscount[_router] = true;
     }
 
     /// @notice Internal function that must be implemented by child contract to enforce admin access control
@@ -48,7 +66,9 @@ abstract contract ReflexAfterSwap {
         _onlyReflexAdmin();
         require(_router != address(0), "Invalid router address");
         address oldRouter = reflexRouter;
+        globalFeeDiscount[oldRouter] = false;
         reflexRouter = _router;
+        globalFeeDiscount[_router] = true;
         emit ReflexRouterUpdated(oldRouter, _router);
     }
 
@@ -72,6 +92,37 @@ abstract contract ReflexAfterSwap {
         bytes32 oldConfigId = reflexConfigId;
         reflexConfigId = _configId;
         emit ReflexConfigIdUpdated(oldConfigId, _configId);
+    }
+
+    /// @notice Sets or removes a global fee discount for an address (applies to all pools)
+    /// @param user The address to set the discount for
+    /// @param discount Whether the discount is active
+    function setGlobalFeeDiscount(address user, bool discount) external {
+        _onlyReflexAdmin();
+        globalFeeDiscount[user] = discount;
+        emit GlobalFeeDiscountSet(user, discount);
+    }
+
+    /// @notice Sets or removes a pool-specific fee discount for an address
+    /// @param poolId The pool ID the discount applies to
+    /// @param user The address to set the discount for
+    /// @param discount Whether the discount is active
+    function setPoolFeeDiscount(bytes32 poolId, address user, bool discount) external {
+        _onlyReflexAdmin();
+        poolFeeDiscount[poolId][user] = discount;
+        emit PoolFeeDiscountSet(poolId, user, discount);
+    }
+
+    /// @notice Checks if an address has a fee discount for a given pool
+    /// @dev Checks pool-specific first, then global; checks sender first, then tx.origin
+    /// @param poolId The pool ID to check
+    /// @param sender The sender address (e.g. router contract calling poolManager.swap)
+    /// @return True if the address has a fee discount
+    function _hasDiscount(bytes32 poolId, address sender) internal view returns (bool) {
+        return poolFeeDiscount[poolId][sender]
+            || globalFeeDiscount[sender]
+            || poolFeeDiscount[poolId][tx.origin]
+            || globalFeeDiscount[tx.origin];
     }
 
     /// @notice Main entry point for post-swap profit extraction via backrunning

--- a/core/src/integrations/plugin/ReflexAfterSwap.sol
+++ b/core/src/integrations/plugin/ReflexAfterSwap.sol
@@ -119,9 +119,7 @@ abstract contract ReflexAfterSwap {
     /// @param sender The sender address (e.g. router contract calling poolManager.swap)
     /// @return True if the address has a fee discount
     function _hasDiscount(bytes32 poolId, address sender) internal view returns (bool) {
-        return poolFeeDiscount[poolId][sender]
-            || globalFeeDiscount[sender]
-            || poolFeeDiscount[poolId][tx.origin]
+        return poolFeeDiscount[poolId][sender] || globalFeeDiscount[sender] || poolFeeDiscount[poolId][tx.origin]
             || globalFeeDiscount[tx.origin];
     }
 

--- a/core/src/integrations/plugin/pancakeswap_infinity/PancakeSwapInfinityHook.sol
+++ b/core/src/integrations/plugin/pancakeswap_infinity/PancakeSwapInfinityHook.sol
@@ -103,14 +103,15 @@ contract PancakeSwapInfinityHook is ICLHooks, ReflexAfterSwap {
         return (this.afterRemoveLiquidity.selector, BalanceDelta.wrap(0));
     }
 
-    function beforeSwap(address sender, PoolKey calldata, ICLPoolManager.SwapParams calldata, bytes calldata)
+    function beforeSwap(address sender, PoolKey calldata key, ICLPoolManager.SwapParams calldata, bytes calldata)
         external
         view
         override
         onlyPoolManager
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        uint24 lpFeeOverride = sender == getRouter() ? LPFeeLibrary.OVERRIDE_FEE_FLAG : 0;
+        bytes32 poolId = PoolId.unwrap(key.toId());
+        uint24 lpFeeOverride = _hasDiscount(poolId, sender) ? LPFeeLibrary.OVERRIDE_FEE_FLAG : 0;
         return (this.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, lpFeeOverride);
     }
 

--- a/core/src/integrations/plugin/uniswapv4/UniswapV4Hook.sol
+++ b/core/src/integrations/plugin/uniswapv4/UniswapV4Hook.sol
@@ -107,14 +107,15 @@ contract UniswapV4Hook is IHooks, ReflexAfterSwap {
         return (IHooks.afterRemoveLiquidity.selector, BalanceDelta.wrap(0));
     }
 
-    function beforeSwap(address sender, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata)
+    function beforeSwap(address sender, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
         external
         view
         override
         onlyPoolManager
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        uint24 lpFeeOverride = sender == getRouter() ? LPFeeLibrary.OVERRIDE_FEE_FLAG : 0;
+        bytes32 poolId = PoolId.unwrap(key.toId());
+        uint24 lpFeeOverride = _hasDiscount(poolId, sender) ? LPFeeLibrary.OVERRIDE_FEE_FLAG : 0;
         return (IHooks.beforeSwap.selector, BeforeSwapDelta.wrap(0), lpFeeOverride);
     }
 

--- a/core/test/integrations/pancakeswap_infinity/PancakeSwapInfinityHook.test.s.sol
+++ b/core/test/integrations/pancakeswap_infinity/PancakeSwapInfinityHook.test.s.sol
@@ -827,7 +827,7 @@ contract PancakeSwapInfinityHookTest is Test {
 
         // alice as sender gets discount
         vm.prank(poolManager);
-        (, , uint24 fee) = hook.beforeSwap(alice, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(alice, key, params, "");
         assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
     }
 
@@ -840,7 +840,7 @@ contract PancakeSwapInfinityHookTest is Test {
 
         // alice as sender gets pool-specific discount
         vm.prank(poolManager);
-        (, , uint24 fee) = hook.beforeSwap(alice, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(alice, key, params, "");
         assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
     }
 
@@ -856,7 +856,7 @@ contract PancakeSwapInfinityHookTest is Test {
 
         // alice has no discount on the other pool
         vm.prank(poolManager);
-        (, , uint24 fee) = hook.beforeSwap(alice, otherKey, params, "");
+        (,, uint24 fee) = hook.beforeSwap(alice, otherKey, params, "");
         assertEq(fee, 0);
     }
 
@@ -866,7 +866,7 @@ contract PancakeSwapInfinityHookTest is Test {
 
         // bob has no discount
         vm.prank(poolManager);
-        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(bob, key, params, "");
         assertEq(fee, 0);
     }
 
@@ -878,7 +878,7 @@ contract PancakeSwapInfinityHookTest is Test {
 
         // sender is bob (no discount), but tx.origin is alice (has discount)
         vm.prank(poolManager, alice);
-        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(bob, key, params, "");
         assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
     }
 
@@ -891,7 +891,7 @@ contract PancakeSwapInfinityHookTest is Test {
 
         // sender is bob (no discount), but tx.origin is alice (has pool discount)
         vm.prank(poolManager, alice);
-        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(bob, key, params, "");
         assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
     }
 

--- a/core/test/integrations/pancakeswap_infinity/PancakeSwapInfinityHook.test.s.sol
+++ b/core/test/integrations/pancakeswap_infinity/PancakeSwapInfinityHook.test.s.sol
@@ -765,4 +765,162 @@ contract PancakeSwapInfinityHookTest is Test {
         vm.expectRevert("PancakeSwapInfinityHook: Only self-call");
         hook._donateToPool(key, token0, true, 100);
     }
+
+    // ========== Fee Discount Tests ==========
+
+    function testRouterGetsGlobalDiscountByDefault() public view {
+        assertTrue(hook.globalFeeDiscount(address(reflexRouter)));
+    }
+
+    function testSetGlobalFeeDiscount() public {
+        hook.setGlobalFeeDiscount(alice, true);
+        assertTrue(hook.globalFeeDiscount(alice));
+    }
+
+    function testSetGlobalFeeDiscountUnauthorized() public {
+        vm.prank(attacker);
+        vm.expectRevert("PancakeSwapInfinityHook: Caller is not the owner");
+        hook.setGlobalFeeDiscount(alice, true);
+    }
+
+    function testRemoveGlobalFeeDiscount() public {
+        hook.setGlobalFeeDiscount(alice, true);
+        assertTrue(hook.globalFeeDiscount(alice));
+
+        hook.setGlobalFeeDiscount(alice, false);
+        assertFalse(hook.globalFeeDiscount(alice));
+    }
+
+    function testSetPoolFeeDiscount() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+
+        hook.setPoolFeeDiscount(poolId, alice, true);
+        assertTrue(hook.poolFeeDiscount(poolId, alice));
+    }
+
+    function testSetPoolFeeDiscountUnauthorized() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+
+        vm.prank(attacker);
+        vm.expectRevert("PancakeSwapInfinityHook: Caller is not the owner");
+        hook.setPoolFeeDiscount(poolId, alice, true);
+    }
+
+    function testRemovePoolFeeDiscount() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+
+        hook.setPoolFeeDiscount(poolId, alice, true);
+        assertTrue(hook.poolFeeDiscount(poolId, alice));
+
+        hook.setPoolFeeDiscount(poolId, alice, false);
+        assertFalse(hook.poolFeeDiscount(poolId, alice));
+    }
+
+    function testBeforeSwapGlobalDiscount() public {
+        hook.setGlobalFeeDiscount(alice, true);
+
+        PoolKey memory key = _createPoolKey();
+        ICLPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // alice as sender gets discount
+        vm.prank(poolManager);
+        (, , uint24 fee) = hook.beforeSwap(alice, key, params, "");
+        assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function testBeforeSwapPoolDiscount() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+        hook.setPoolFeeDiscount(poolId, alice, true);
+
+        ICLPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // alice as sender gets pool-specific discount
+        vm.prank(poolManager);
+        (, , uint24 fee) = hook.beforeSwap(alice, key, params, "");
+        assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function testBeforeSwapPoolDiscountDoesNotAffectOtherPools() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+        hook.setPoolFeeDiscount(poolId, alice, true);
+
+        // Create a different pool key
+        PoolKey memory otherKey = _createPoolKey(address(0x3333), address(0x4444));
+
+        ICLPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // alice has no discount on the other pool
+        vm.prank(poolManager);
+        (, , uint24 fee) = hook.beforeSwap(alice, otherKey, params, "");
+        assertEq(fee, 0);
+    }
+
+    function testBeforeSwapNoDiscount() public {
+        PoolKey memory key = _createPoolKey();
+        ICLPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // bob has no discount
+        vm.prank(poolManager);
+        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        assertEq(fee, 0);
+    }
+
+    function testBeforeSwapGlobalDiscountViaTxOrigin() public {
+        hook.setGlobalFeeDiscount(alice, true);
+
+        PoolKey memory key = _createPoolKey();
+        ICLPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // sender is bob (no discount), but tx.origin is alice (has discount)
+        vm.prank(poolManager, alice);
+        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function testBeforeSwapPoolDiscountViaTxOrigin() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+        hook.setPoolFeeDiscount(poolId, alice, true);
+
+        ICLPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // sender is bob (no discount), but tx.origin is alice (has pool discount)
+        vm.prank(poolManager, alice);
+        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function testSetReflexRouterMigratesDiscount() public {
+        // Router should have global discount initially
+        assertTrue(hook.globalFeeDiscount(address(reflexRouter)));
+
+        address newRouter = makeAddr("newRouter");
+        hook.setReflexRouter(newRouter);
+
+        // Old router loses discount, new router gets it
+        assertFalse(hook.globalFeeDiscount(address(reflexRouter)));
+        assertTrue(hook.globalFeeDiscount(newRouter));
+    }
+
+    function testGlobalFeeDiscountSetEvent() public {
+        vm.expectEmit(true, false, false, true);
+        emit GlobalFeeDiscountSet(alice, true);
+        hook.setGlobalFeeDiscount(alice, true);
+    }
+
+    function testPoolFeeDiscountSetEvent() public {
+        bytes32 poolId = keccak256("test-pool");
+        vm.expectEmit(true, true, false, true);
+        emit PoolFeeDiscountSet(poolId, alice, true);
+        hook.setPoolFeeDiscount(poolId, alice, true);
+    }
+
+    // Re-declare events for expectEmit
+    event GlobalFeeDiscountSet(address indexed user, bool discount);
+    event PoolFeeDiscountSet(bytes32 indexed poolId, address indexed user, bool discount);
 }

--- a/core/test/integrations/uniswapv4/UniswapV4Hook.test.s.sol
+++ b/core/test/integrations/uniswapv4/UniswapV4Hook.test.s.sol
@@ -731,4 +731,162 @@ contract UniswapV4HookTest is Test {
         vm.expectRevert("UniswapV4Hook: Only self-call");
         hook._donateToPool(key, token0, true, 100);
     }
+
+    // ========== Fee Discount Tests ==========
+
+    function testRouterGetsGlobalDiscountByDefault() public view {
+        assertTrue(hook.globalFeeDiscount(address(reflexRouter)));
+    }
+
+    function testSetGlobalFeeDiscount() public {
+        hook.setGlobalFeeDiscount(alice, true);
+        assertTrue(hook.globalFeeDiscount(alice));
+    }
+
+    function testSetGlobalFeeDiscountUnauthorized() public {
+        vm.prank(attacker);
+        vm.expectRevert("UniswapV4Hook: Caller is not the owner");
+        hook.setGlobalFeeDiscount(alice, true);
+    }
+
+    function testRemoveGlobalFeeDiscount() public {
+        hook.setGlobalFeeDiscount(alice, true);
+        assertTrue(hook.globalFeeDiscount(alice));
+
+        hook.setGlobalFeeDiscount(alice, false);
+        assertFalse(hook.globalFeeDiscount(alice));
+    }
+
+    function testSetPoolFeeDiscount() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+
+        hook.setPoolFeeDiscount(poolId, alice, true);
+        assertTrue(hook.poolFeeDiscount(poolId, alice));
+    }
+
+    function testSetPoolFeeDiscountUnauthorized() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+
+        vm.prank(attacker);
+        vm.expectRevert("UniswapV4Hook: Caller is not the owner");
+        hook.setPoolFeeDiscount(poolId, alice, true);
+    }
+
+    function testRemovePoolFeeDiscount() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+
+        hook.setPoolFeeDiscount(poolId, alice, true);
+        assertTrue(hook.poolFeeDiscount(poolId, alice));
+
+        hook.setPoolFeeDiscount(poolId, alice, false);
+        assertFalse(hook.poolFeeDiscount(poolId, alice));
+    }
+
+    function testBeforeSwapGlobalDiscount() public {
+        hook.setGlobalFeeDiscount(alice, true);
+
+        PoolKey memory key = _createPoolKey();
+        IPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // alice as sender gets discount
+        vm.prank(poolManager);
+        (, , uint24 fee) = hook.beforeSwap(alice, key, params, "");
+        assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function testBeforeSwapPoolDiscount() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+        hook.setPoolFeeDiscount(poolId, alice, true);
+
+        IPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // alice as sender gets pool-specific discount
+        vm.prank(poolManager);
+        (, , uint24 fee) = hook.beforeSwap(alice, key, params, "");
+        assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function testBeforeSwapPoolDiscountDoesNotAffectOtherPools() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+        hook.setPoolFeeDiscount(poolId, alice, true);
+
+        // Create a different pool key
+        PoolKey memory otherKey = _createPoolKey(address(0x3333), address(0x4444));
+
+        IPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // alice has no discount on the other pool
+        vm.prank(poolManager);
+        (, , uint24 fee) = hook.beforeSwap(alice, otherKey, params, "");
+        assertEq(fee, 0);
+    }
+
+    function testBeforeSwapNoDiscount() public {
+        PoolKey memory key = _createPoolKey();
+        IPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // bob has no discount
+        vm.prank(poolManager);
+        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        assertEq(fee, 0);
+    }
+
+    function testBeforeSwapGlobalDiscountViaTxOrigin() public {
+        hook.setGlobalFeeDiscount(alice, true);
+
+        PoolKey memory key = _createPoolKey();
+        IPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // sender is bob (no discount), but tx.origin is alice (has discount)
+        vm.prank(poolManager, alice);
+        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function testBeforeSwapPoolDiscountViaTxOrigin() public {
+        PoolKey memory key = _createPoolKey();
+        bytes32 poolId = PoolId.unwrap(key.toId());
+        hook.setPoolFeeDiscount(poolId, alice, true);
+
+        IPoolManager.SwapParams memory params = _createSwapParams(true, -1000e18);
+
+        // sender is bob (no discount), but tx.origin is alice (has pool discount)
+        vm.prank(poolManager, alice);
+        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function testSetReflexRouterMigratesDiscount() public {
+        // Router should have global discount initially
+        assertTrue(hook.globalFeeDiscount(address(reflexRouter)));
+
+        address newRouter = makeAddr("newRouter");
+        hook.setReflexRouter(newRouter);
+
+        // Old router loses discount, new router gets it
+        assertFalse(hook.globalFeeDiscount(address(reflexRouter)));
+        assertTrue(hook.globalFeeDiscount(newRouter));
+    }
+
+    function testGlobalFeeDiscountSetEvent() public {
+        vm.expectEmit(true, false, false, true);
+        emit GlobalFeeDiscountSet(alice, true);
+        hook.setGlobalFeeDiscount(alice, true);
+    }
+
+    function testPoolFeeDiscountSetEvent() public {
+        bytes32 poolId = keccak256("test-pool");
+        vm.expectEmit(true, true, false, true);
+        emit PoolFeeDiscountSet(poolId, alice, true);
+        hook.setPoolFeeDiscount(poolId, alice, true);
+    }
+
+    // Re-declare events for expectEmit
+    event GlobalFeeDiscountSet(address indexed user, bool discount);
+    event PoolFeeDiscountSet(bytes32 indexed poolId, address indexed user, bool discount);
 }

--- a/core/test/integrations/uniswapv4/UniswapV4Hook.test.s.sol
+++ b/core/test/integrations/uniswapv4/UniswapV4Hook.test.s.sol
@@ -793,7 +793,7 @@ contract UniswapV4HookTest is Test {
 
         // alice as sender gets discount
         vm.prank(poolManager);
-        (, , uint24 fee) = hook.beforeSwap(alice, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(alice, key, params, "");
         assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
     }
 
@@ -806,7 +806,7 @@ contract UniswapV4HookTest is Test {
 
         // alice as sender gets pool-specific discount
         vm.prank(poolManager);
-        (, , uint24 fee) = hook.beforeSwap(alice, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(alice, key, params, "");
         assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
     }
 
@@ -822,7 +822,7 @@ contract UniswapV4HookTest is Test {
 
         // alice has no discount on the other pool
         vm.prank(poolManager);
-        (, , uint24 fee) = hook.beforeSwap(alice, otherKey, params, "");
+        (,, uint24 fee) = hook.beforeSwap(alice, otherKey, params, "");
         assertEq(fee, 0);
     }
 
@@ -832,7 +832,7 @@ contract UniswapV4HookTest is Test {
 
         // bob has no discount
         vm.prank(poolManager);
-        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(bob, key, params, "");
         assertEq(fee, 0);
     }
 
@@ -844,7 +844,7 @@ contract UniswapV4HookTest is Test {
 
         // sender is bob (no discount), but tx.origin is alice (has discount)
         vm.prank(poolManager, alice);
-        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(bob, key, params, "");
         assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
     }
 
@@ -857,7 +857,7 @@ contract UniswapV4HookTest is Test {
 
         // sender is bob (no discount), but tx.origin is alice (has pool discount)
         vm.prank(poolManager, alice);
-        (, , uint24 fee) = hook.beforeSwap(bob, key, params, "");
+        (,, uint24 fee) = hook.beforeSwap(bob, key, params, "");
         assertEq(fee, LPFeeLibrary.OVERRIDE_FEE_FLAG);
     }
 


### PR DESCRIPTION
Feature: Protocol Fee Discount System

Replaces the hardcoded router fee exemption (`sender == getRouter()`) with a general-purpose fee discount system. The hook admin can now grant any address a full (100%) LP fee waiver, either globally (all pools) or on a specific pool.

ReflexAfterSwap.sol (shared base contract):
- Added two mappings: `globalFeeDiscount(address => bool)` and `poolFeeDiscount(poolId => address => bool)`
- Added admin functions `setGlobalFeeDiscount()` and `setPoolFeeDiscount()`, both gated by `_onlyReflexAdmin()`
- Added internal `_hasDiscount(poolId, sender)` which checks 4 lookups in priority order: pool+sender, global+sender, pool+tx.origin, global+tx.origin
- Constructor now sets `globalFeeDiscount[router] = true` (preserving existing router behavior)
- `setReflexRouter()` migrates the discount from old router to new router

UniswapV4Hook.sol & PancakeSwapInfinityHook.sol (beforeSwap only):
- Replaced `sender == getRouter()` with `_hasDiscount(poolId, sender)`
- No changes to afterSwap, donation logic, or any other functions

Behavioral guarantees:
- Existing router behavior is unchanged — the router gets its fee waiver through the global discount set in the constructor
- Non-discounted swaps are unaffected (mapping reads return false by default)
- afterSwap and all donation/profit distribution logic is untouched