### PR TITLE
[FIX] Address V2 audit findings I-05, I-06, I-07

### DIFF
--- a/core/script/uniswapv4/00_DeployHook.s.sol
+++ b/core/script/uniswapv4/00_DeployHook.s.sol
@@ -12,7 +12,7 @@ import {UniswapV4BaseScript} from "./base/UniswapV4BaseScript.sol";
  * @title DeployHook
  * @notice Deployment script for UniswapV4Hook with CREATE2 salt mining
  * @dev Uniswap V4 hooks must be deployed at addresses where specific permission bits are set.
- *      For our hook, BEFORE_SWAP_FLAG | AFTER_SWAP_FLAG must be set in the bottom 14 bits.
+ *      For our hook, AFTER_INITIALIZE_FLAG | BEFORE_SWAP_FLAG | AFTER_SWAP_FLAG must be set in the bottom 14 bits.
  *      This script mines a CREATE2 salt to find such an address.
  *
  * Run with:
@@ -31,7 +31,7 @@ import {UniswapV4BaseScript} from "./base/UniswapV4BaseScript.sol";
  */
 contract DeployHook is UniswapV4BaseScript {
     // Hook permission flags
-    uint160 constant REQUIRED_FLAGS = Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG;
+    uint160 constant REQUIRED_FLAGS = Hooks.AFTER_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG;
     uint160 constant FLAG_MASK = Hooks.ALL_HOOK_MASK; // (1 << 14) - 1 = 0x3FFF
 
     // Contract instance
@@ -80,7 +80,7 @@ contract DeployHook is UniswapV4BaseScript {
         );
         bytes32 initcodeHash = keccak256(initcode);
 
-        // Mine CREATE2 salt: find salt where deployed address has exactly BEFORE_SWAP_FLAG | AFTER_SWAP_FLAG set in bottom 14 bits
+        // Mine CREATE2 salt: find salt where deployed address has exactly REQUIRED_FLAGS set in bottom 14 bits
         bool found = false;
         for (uint256 i = 0; i < type(uint256).max; i++) {
             bytes32 salt = bytes32(i);

--- a/core/src/integrations/plugin/pancakeswap_infinity/PancakeSwapInfinityHook.sol
+++ b/core/src/integrations/plugin/pancakeswap_infinity/PancakeSwapInfinityHook.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {
     ICLHooks,
+    HOOKS_AFTER_INITIALIZE_OFFSET,
     HOOKS_BEFORE_SWAP_OFFSET,
     HOOKS_AFTER_SWAP_OFFSET
 } from "infinity-core/src/pool-cl/interfaces/ICLHooks.sol";
@@ -16,6 +17,7 @@ import {Currency} from "infinity-core/src/types/Currency.sol";
 import {LPFeeLibrary} from "infinity-core/src/libraries/LPFeeLibrary.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable, Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import "../ReflexAfterSwap.sol";
 
 interface IWETH9 {
@@ -23,13 +25,12 @@ interface IWETH9 {
     function withdraw(uint256) external;
 }
 
-contract PancakeSwapInfinityHook is ICLHooks, ReflexAfterSwap {
+contract PancakeSwapInfinityHook is ICLHooks, ReflexAfterSwap, Ownable2Step {
     using PoolIdLibrary for PoolKey;
     using SafeERC20 for IERC20;
 
     ICLPoolManager public immutable poolManager;
     IVault public immutable vault;
-    address public immutable owner;
     address public immutable weth;
 
     modifier onlyPoolManager() {
@@ -41,25 +42,38 @@ contract PancakeSwapInfinityHook is ICLHooks, ReflexAfterSwap {
 
     constructor(ICLPoolManager _poolManager, address _reflexRouter, bytes32 _configId, address _owner, address _weth)
         ReflexAfterSwap(_reflexRouter, _configId)
+        Ownable(_owner)
     {
-        require(_owner != address(0), "PancakeSwapInfinityHook: Owner cannot be zero address");
         poolManager = _poolManager;
         vault = _poolManager.vault();
-        owner = _owner;
         weth = _weth;
     }
 
     /// @notice Returns the hook registration bitmap for PancakeSwap Infinity
-    /// @dev Enables beforeSwap (bit 6) and afterSwap (bit 7)
+    /// @dev Enables afterInitialize (bit 1), beforeSwap (bit 6), afterSwap (bit 7)
     function getHooksRegistrationBitmap() external pure override returns (uint16) {
-        return uint16((1 << HOOKS_BEFORE_SWAP_OFFSET) | (1 << HOOKS_AFTER_SWAP_OFFSET));
+        return
+            uint16(
+                (1 << HOOKS_AFTER_INITIALIZE_OFFSET) | (1 << HOOKS_BEFORE_SWAP_OFFSET) | (1 << HOOKS_AFTER_SWAP_OFFSET)
+            );
     }
 
     function beforeInitialize(address, PoolKey calldata, uint160) external pure override returns (bytes4) {
         return this.beforeInitialize.selector;
     }
 
-    function afterInitialize(address, PoolKey calldata, uint160, int24) external pure override returns (bytes4) {
+    /// @notice Rejects pool initialization unless the pool is configured with the dynamic-fee flag.
+    /// @dev The hook's fee-discount mechanism overrides the LP fee via beforeSwap, which is only
+    ///      honored by the pool manager on dynamic-fee pools. Without this check, the hook would
+    ///      silently no-op on static-fee pools.
+    function afterInitialize(address, PoolKey calldata key, uint160, int24)
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4)
+    {
+        require(LPFeeLibrary.isDynamicLPFee(key.fee), "PancakeSwapInfinityHook: Dynamic-fee pool required");
         return this.afterInitialize.selector;
     }
 
@@ -153,7 +167,7 @@ contract PancakeSwapInfinityHook is ICLHooks, ReflexAfterSwap {
         bool matchesCurrency1 = _matchesCurrency(profitToken, key.currency1);
 
         if (matchesCurrency0 || matchesCurrency1) {
-            try this._donateToPool(key, profitToken, matchesCurrency0, lpAmount) {}
+            try this.donateToPool(key, profitToken, matchesCurrency0, lpAmount) {}
             catch {
                 // Donate failed (e.g., no in-range liquidity) — send to tx.origin as fallback
                 IERC20(profitToken).safeTransfer(tx.origin, lpAmount);
@@ -173,7 +187,7 @@ contract PancakeSwapInfinityHook is ICLHooks, ReflexAfterSwap {
     /// @notice Donates profit tokens to in-range LPs via PoolManager.donate()
     /// @dev Must be external so it can be called via try-catch from afterSwap.
     ///      Only callable by this contract itself.
-    function _donateToPool(PoolKey calldata key, address profitToken, bool isCurrency0, uint256 amount) external {
+    function donateToPool(PoolKey calldata key, address profitToken, bool isCurrency0, uint256 amount) external {
         require(msg.sender == address(this), "PancakeSwapInfinityHook: Only self-call");
 
         Currency currency = isCurrency0 ? key.currency0 : key.currency1;
@@ -213,6 +227,6 @@ contract PancakeSwapInfinityHook is ICLHooks, ReflexAfterSwap {
 
     /// @inheritdoc ReflexAfterSwap
     function _onlyReflexAdmin() internal view override {
-        require(msg.sender == owner, "PancakeSwapInfinityHook: Caller is not the owner");
+        require(msg.sender == owner(), "PancakeSwapInfinityHook: Caller is not the owner");
     }
 }

--- a/core/src/integrations/plugin/uniswapv4/UniswapV4Hook.sol
+++ b/core/src/integrations/plugin/uniswapv4/UniswapV4Hook.sol
@@ -12,15 +12,15 @@ import {Hooks} from "v4-core/src/libraries/Hooks.sol";
 import {LPFeeLibrary} from "v4-core/src/libraries/LPFeeLibrary.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable, Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IWETH9} from "v4-periphery/src/interfaces/external/IWETH9.sol";
 import "../ReflexAfterSwap.sol";
 
-contract UniswapV4Hook is IHooks, ReflexAfterSwap {
+contract UniswapV4Hook is IHooks, ReflexAfterSwap, Ownable2Step {
     using PoolIdLibrary for PoolKey;
     using SafeERC20 for IERC20;
 
     IPoolManager public immutable poolManager;
-    address public immutable owner;
     address public immutable weth;
 
     modifier onlyPoolManager() {
@@ -32,17 +32,16 @@ contract UniswapV4Hook is IHooks, ReflexAfterSwap {
 
     constructor(IPoolManager _poolManager, address _reflexRouter, bytes32 _configId, address _owner, address _weth)
         ReflexAfterSwap(_reflexRouter, _configId)
+        Ownable(_owner)
     {
-        require(_owner != address(0), "UniswapV4Hook: Owner cannot be zero address");
         poolManager = _poolManager;
-        owner = _owner;
         weth = _weth;
 
         Hooks.validateHookPermissions(
             IHooks(address(this)),
             Hooks.Permissions({
                 beforeInitialize: false,
-                afterInitialize: false,
+                afterInitialize: true,
                 beforeAddLiquidity: false,
                 afterAddLiquidity: false,
                 beforeRemoveLiquidity: false,
@@ -63,7 +62,18 @@ contract UniswapV4Hook is IHooks, ReflexAfterSwap {
         return IHooks.beforeInitialize.selector;
     }
 
-    function afterInitialize(address, PoolKey calldata, uint160, int24) external pure override returns (bytes4) {
+    /// @notice Rejects pool initialization unless the pool is configured with V4's dynamic-fee flag.
+    /// @dev The hook's fee-discount mechanism overrides the LP fee via beforeSwap, which is only
+    ///      honored by PoolManager on dynamic-fee pools. Without this check, the hook would
+    ///      silently no-op on static-fee pools.
+    function afterInitialize(address, PoolKey calldata key, uint160, int24)
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4)
+    {
+        require(LPFeeLibrary.isDynamicFee(key.fee), "UniswapV4Hook: Dynamic-fee pool required");
         return IHooks.afterInitialize.selector;
     }
 
@@ -157,7 +167,7 @@ contract UniswapV4Hook is IHooks, ReflexAfterSwap {
         bool matchesCurrency1 = _matchesCurrency(profitToken, key.currency1);
 
         if (matchesCurrency0 || matchesCurrency1) {
-            try this._donateToPool(key, profitToken, matchesCurrency0, lpAmount) {}
+            try this.donateToPool(key, profitToken, matchesCurrency0, lpAmount) {}
             catch {
                 // Donate failed (e.g., no in-range liquidity) — send to tx.origin as fallback
                 IERC20(profitToken).safeTransfer(tx.origin, lpAmount);
@@ -181,7 +191,7 @@ contract UniswapV4Hook is IHooks, ReflexAfterSwap {
     /// @param profitToken The profit token address (may be WETH for native ETH pools)
     /// @param isCurrency0 Whether the profit token matches currency0 (false = currency1)
     /// @param amount The amount to donate
-    function _donateToPool(PoolKey calldata key, address profitToken, bool isCurrency0, uint256 amount) external {
+    function donateToPool(PoolKey calldata key, address profitToken, bool isCurrency0, uint256 amount) external {
         require(msg.sender == address(this), "UniswapV4Hook: Only self-call");
 
         Currency currency = isCurrency0 ? key.currency0 : key.currency1;
@@ -221,6 +231,6 @@ contract UniswapV4Hook is IHooks, ReflexAfterSwap {
 
     /// @inheritdoc ReflexAfterSwap
     function _onlyReflexAdmin() internal view override {
-        require(msg.sender == owner, "UniswapV4Hook: Caller is not the owner");
+        require(msg.sender == owner(), "UniswapV4Hook: Caller is not the owner");
     }
 }

--- a/core/test/integrations/pancakeswap_infinity/PancakeSwapInfinityHook.test.s.sol
+++ b/core/test/integrations/pancakeswap_infinity/PancakeSwapInfinityHook.test.s.sol
@@ -29,6 +29,7 @@ import {IProtocolFees} from "infinity-core/src/interfaces/IProtocolFees.sol";
 import {CLPoolParametersHelper} from "infinity-core/src/pool-cl/libraries/CLPoolParametersHelper.sol";
 import {LPFeeLibrary} from "infinity-core/src/libraries/LPFeeLibrary.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import "../../utils/TestUtils.sol";
 import "../../mocks/MockToken.sol";
 import "../../mocks/MockReflexRouter.sol";
@@ -55,8 +56,9 @@ contract PancakeSwapInfinityHookTest is Test {
 
     bytes32 public configIdFixture = keccak256("pancakeswap-infinity-config");
 
-    // Hook bitmap for beforeSwap + afterSwap
-    uint16 constant EXPECTED_BITMAP = uint16((1 << HOOKS_BEFORE_SWAP_OFFSET) | (1 << HOOKS_AFTER_SWAP_OFFSET));
+    // Hook bitmap for afterInitialize + beforeSwap + afterSwap
+    uint16 constant EXPECTED_BITMAP =
+        uint16((1 << HOOKS_AFTER_INITIALIZE_OFFSET) | (1 << HOOKS_BEFORE_SWAP_OFFSET) | (1 << HOOKS_AFTER_SWAP_OFFSET));
 
     function setUp() public {
         admin = address(this);
@@ -136,8 +138,8 @@ contract PancakeSwapInfinityHookTest is Test {
         // Verify specific bits
         assertTrue(bitmap & (1 << HOOKS_BEFORE_SWAP_OFFSET) != 0, "beforeSwap should be enabled");
         assertTrue(bitmap & (1 << HOOKS_AFTER_SWAP_OFFSET) != 0, "afterSwap should be enabled");
+        assertTrue(bitmap & (1 << HOOKS_AFTER_INITIALIZE_OFFSET) != 0, "afterInitialize should be enabled");
         assertTrue(bitmap & (1 << HOOKS_BEFORE_INITIALIZE_OFFSET) == 0, "beforeInitialize should be disabled");
-        assertTrue(bitmap & (1 << HOOKS_AFTER_INITIALIZE_OFFSET) == 0, "afterInitialize should be disabled");
         assertTrue(bitmap & (1 << HOOKS_BEFORE_ADD_LIQUIDITY_OFFSET) == 0, "beforeAddLiquidity should be disabled");
         assertTrue(bitmap & (1 << HOOKS_AFTER_ADD_LIQUIDITY_OFFSET) == 0, "afterAddLiquidity should be disabled");
         assertTrue(
@@ -150,7 +152,7 @@ contract PancakeSwapInfinityHookTest is Test {
 
     function testConstructorZeroOwnerReverts() public {
         vm.mockCall(poolManager, abi.encodeWithSelector(IProtocolFees.vault.selector), abi.encode(vaultAddr));
-        vm.expectRevert("PancakeSwapInfinityHook: Owner cannot be zero address");
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableInvalidOwner.selector, address(0)));
         new PancakeSwapInfinityHook(
             ICLPoolManager(poolManager), address(reflexRouter), configIdFixture, address(0), wethAddr
         );
@@ -374,10 +376,27 @@ contract PancakeSwapInfinityHookTest is Test {
         assertEq(selector, hook.beforeInitialize.selector);
     }
 
-    function testAfterInitializeNoOp() public view {
+    function testAfterInitializeRequiresDynamicFeeFlag() public {
+        PoolKey memory staticFeeKey = _createPoolKey();
+        vm.prank(poolManager);
+        vm.expectRevert("PancakeSwapInfinityHook: Dynamic-fee pool required");
+        hook.afterInitialize(address(0), staticFeeKey, 0, 0);
+    }
+
+    function testAfterInitializeAcceptsDynamicFeePool() public {
         PoolKey memory key = _createPoolKey();
+        key.fee = LPFeeLibrary.DYNAMIC_FEE_FLAG;
+        vm.prank(poolManager);
         bytes4 selector = hook.afterInitialize(address(0), key, 0, 0);
         assertEq(selector, hook.afterInitialize.selector);
+    }
+
+    function testAfterInitializeOnlyPoolManager() public {
+        PoolKey memory key = _createPoolKey();
+        key.fee = LPFeeLibrary.DYNAMIC_FEE_FLAG;
+        vm.prank(attacker);
+        vm.expectRevert("PancakeSwapInfinityHook: Caller is not the PoolManager");
+        hook.afterInitialize(address(0), key, 0, 0);
     }
 
     function testBeforeSwapNonRouterNoOverride() public {
@@ -763,7 +782,7 @@ contract PancakeSwapInfinityHookTest is Test {
         PoolKey memory key = _createPoolKey();
 
         vm.expectRevert("PancakeSwapInfinityHook: Only self-call");
-        hook._donateToPool(key, token0, true, 100);
+        hook.donateToPool(key, token0, true, 100);
     }
 
     // ========== Fee Discount Tests ==========

--- a/core/test/integrations/uniswapv4/UniswapV4Hook.test.s.sol
+++ b/core/test/integrations/uniswapv4/UniswapV4Hook.test.s.sol
@@ -50,7 +50,7 @@ contract UniswapV4HookTest is Test {
         wethAddr = makeAddr("weth");
 
         // Compute hook address with BEFORE_SWAP_FLAG | AFTER_SWAP_FLAG set in the last 14 bits
-        uint160 flags = uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
+        uint160 flags = uint160(Hooks.AFTER_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
 
         // Deploy hook to a flag-compliant address
         deployCodeTo(
@@ -107,11 +107,11 @@ contract UniswapV4HookTest is Test {
 
     function testHookPermissions() public view {
         address hookAddr = address(hook);
-        // BEFORE_SWAP_FLAG and AFTER_SWAP_FLAG should be set
+        // AFTER_INITIALIZE_FLAG, BEFORE_SWAP_FLAG, and AFTER_SWAP_FLAG should be set
         assertTrue(_hasPermission(hookAddr, Hooks.AFTER_SWAP_FLAG));
         assertTrue(_hasPermission(hookAddr, Hooks.BEFORE_SWAP_FLAG));
+        assertTrue(_hasPermission(hookAddr, Hooks.AFTER_INITIALIZE_FLAG));
         assertFalse(_hasPermission(hookAddr, Hooks.BEFORE_INITIALIZE_FLAG));
-        assertFalse(_hasPermission(hookAddr, Hooks.AFTER_INITIALIZE_FLAG));
         assertFalse(_hasPermission(hookAddr, Hooks.BEFORE_ADD_LIQUIDITY_FLAG));
         assertFalse(_hasPermission(hookAddr, Hooks.AFTER_ADD_LIQUIDITY_FLAG));
         assertFalse(_hasPermission(hookAddr, Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG));
@@ -345,10 +345,37 @@ contract UniswapV4HookTest is Test {
         assertEq(selector, IHooks.beforeInitialize.selector);
     }
 
-    function testAfterInitializeNoOp() public view {
-        PoolKey memory key = _createPoolKey();
-        bytes4 selector = hook.afterInitialize(address(0), key, 0, 0);
+    function testAfterInitializeRequiresDynamicFeeFlag() public {
+        PoolKey memory staticFeeKey = _createPoolKey();
+        vm.prank(poolManager);
+        vm.expectRevert("UniswapV4Hook: Dynamic-fee pool required");
+        hook.afterInitialize(address(0), staticFeeKey, 0, 0);
+    }
+
+    function testAfterInitializeAcceptsDynamicFeePool() public {
+        PoolKey memory dynamicFeeKey = PoolKey({
+            currency0: Currency.wrap(token0),
+            currency1: Currency.wrap(token1),
+            fee: LPFeeLibrary.DYNAMIC_FEE_FLAG,
+            tickSpacing: 60,
+            hooks: IHooks(address(hook))
+        });
+        vm.prank(poolManager);
+        bytes4 selector = hook.afterInitialize(address(0), dynamicFeeKey, 0, 0);
         assertEq(selector, IHooks.afterInitialize.selector);
+    }
+
+    function testAfterInitializeOnlyPoolManager() public {
+        PoolKey memory dynamicFeeKey = PoolKey({
+            currency0: Currency.wrap(token0),
+            currency1: Currency.wrap(token1),
+            fee: LPFeeLibrary.DYNAMIC_FEE_FLAG,
+            tickSpacing: 60,
+            hooks: IHooks(address(hook))
+        });
+        vm.prank(attacker);
+        vm.expectRevert("UniswapV4Hook: Caller is not the PoolManager");
+        hook.afterInitialize(address(0), dynamicFeeKey, 0, 0);
     }
 
     function testBeforeSwapNonRouterNoOverride() public {
@@ -487,7 +514,7 @@ contract UniswapV4HookTest is Test {
     {
         donateRouter = MockReflexRouter(TestUtils.createMockReflexRouter(admin, _profitTokenAddr));
 
-        uint160 flags = uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
+        uint160 flags = uint160(Hooks.AFTER_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
         deployCodeTo(
             "UniswapV4Hook.sol:UniswapV4Hook",
             abi.encode(IPoolManager(poolManager), address(donateRouter), testConfigId, address(this), wethAddr),
@@ -576,7 +603,7 @@ contract UniswapV4HookTest is Test {
         address wethToken = address(profitToken);
         MockReflexRouter wethRouter = MockReflexRouter(TestUtils.createMockReflexRouter(admin, wethToken));
 
-        uint160 flags = uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
+        uint160 flags = uint160(Hooks.AFTER_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
         deployCodeTo(
             "UniswapV4Hook.sol:UniswapV4Hook",
             abi.encode(IPoolManager(poolManager), address(wethRouter), testConfigId, address(this), wethToken),
@@ -729,7 +756,7 @@ contract UniswapV4HookTest is Test {
         PoolKey memory key = _createPoolKey();
 
         vm.expectRevert("UniswapV4Hook: Only self-call");
-        hook._donateToPool(key, token0, true, 100);
+        hook.donateToPool(key, token0, true, 100);
     }
 
     // ========== Fee Discount Tests ==========


### PR DESCRIPTION
## Summary

Fixes three informational audit findings on the Uniswap V4 and PancakeSwap Infinity hooks.

- **I-05 — Enforce dynamic-fee flag at pool registration.** The fee-discount mechanism overrides the LP fee via `beforeSwap`, which the pool manager only honors on dynamic-fee pools. Without this check, registering the hook on a static-fee pool would silently no-op the discount. Both hooks now revert in `afterInitialize` unless the pool was created with `DYNAMIC_FEE_FLAG`.
- **I-06 — Rotatable owner.** Replaces `address public immutable owner` with OpenZeppelin `Ownable2Step` on both hooks. This is particularly important for the V4 hook, whose address is mined — redeploying solely to rotate ownership would invalidate every integrated pool.
- **I-07 — Naming convention.** Renames the externally callable `_donateToPool` → `donateToPool`. The leading underscore is reserved for internal/private visibility by Solidity convention; an underscored external function is a reviewer footgun.

## Deployment notes

- The V4 hook now registers the `afterInitialize` permission bit, so its required deployed address pattern has changed. Any previously mined CREATE2 salt is invalid; mine a new one before redeployment. The deploy script (`script/uniswapv4/00_DeployHook.s.sol`) has been updated with the new `REQUIRED_FLAGS`.
- PancakeSwap Infinity stores permissions in `PoolKey.parameters` rather than the hook address, so there is no address-mining impact there.

## Test plan

- [x] `forge test` — 339/339 pass (V4 hook suite 55/55, PancakeSwap Infinity 54/54)
- [x] `forge fmt --check` clean
- [x] New tests cover: `afterInitialize` rejecting static-fee pools, accepting dynamic-fee pools, rejecting non-poolManager callers
- [x] Existing owner-auth tests still pass unmodified (OZ `Ownable`'s `owner()` getter is drop-in compatible with prior callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)